### PR TITLE
Mount AmazonCloud Drive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.tfstate
 *.tfstate*
 terraform.tfvars
+oauth_data

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ $ terraform apply
 $ ./ansible.sh
 ```
 
+## Directories
+
+In order to operate smoothly, this system utilizes [UnionFS](https://amc.ovh/2015/08/15/uniting-encrypted-encfs-filesystems.html) to allow Plex to access both local files, and content found on Amazon CloudDrive.
+
+Example:
+```
+/root/movies
+├── /root/acd/movies
+└── /root/local/movies
+```
+
+
 ## Configuring
 
 ### Plex

--- a/README.md
+++ b/README.md
@@ -17,14 +17,12 @@ On December 15th, Plex announced [they would no longer be supporting Amazon Clou
 
 ## Setup
 
-Login at <https://tensile-runway-92512.appspot.com/>, and copy the downloaded file to `provisioning/roles/aws/files/oauth_data`.
+See [here](./SETUP.md).
 
 ## Running
 
 ```bash
-$ cd terraform
-$ terraform apply
-$ ./ansible.sh
+$ ./do_it.sh
 ```
 
 ## Directories

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ On December 15th, Plex announced [they would no longer be supporting Amazon Clou
 
 ## Setup
 
+Login at <https://tensile-runway-92512.appspot.com/>, and copy the downloaded file to `provisioning/roles/aws/files/oauth_data`.
+
 ## Running
 
 ```bash
@@ -36,6 +38,7 @@ Example:
 └── /root/local/movies
 ```
 
+Transmission downloads files to `/root/downloads`.  CouchPotato will move files into `/root/local/movies`, and a nightly `cron` job will upload them to Amazon CloudDrive, at which point they will be located in `/root/acd/movies`.  In order for files to be available both pre- and post-upload, the folders are joint mounted using UnionFS at `/root/movies`.
 
 ## Configuring
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,25 @@
+# Setup
+
+A few steps are needed to prepare yourself to run these scripts.  As a start, `cp ./terraform/terraform.tfvars.example ./terraform/terraform.tfvars`.
+
+## DigitalOcean
+
+### Token
+
+After creating a DigitalOcean account, you'll want to get a token from the [settings page](https://cloud.digitalocean.com/settings/api/tokens).  Place that token as `do_token` in `./terarform/terraform.tfvars`.
+
+### SSH Key ID
+
+Ensure you've added your public key to [your account](https://cloud.digitalocean.com/settings/security).  After that, get the key ID by issuing the following `curl` command:
+
+```bash
+$ curl -X GET -H "Authorization: Bearer API_TOKEN_HERE" "https://api.digitalocean.com/v2/account/keys"
+```
+
+You'll receive a JSON response.  Copy the `id` of the first `ssh_keys` object into the `ssh_key_id` within `./terraform/terraform.tfvars`.
+
+## Plex
+
+### Claim Token
+
+In order to have your server automatically claimed at startup, go to <https://www.plex.tv/claim/> and copy the token into `./provisioning/group_vars/all.yml`.  You'll want to do this as the very last setup step, as the token is only good for 5 minutes.

--- a/SETUP.md
+++ b/SETUP.md
@@ -18,6 +18,12 @@ $ curl -X GET -H "Authorization: Bearer API_TOKEN_HERE" "https://api.digitalocea
 
 You'll receive a JSON response.  Copy the `id` of the first `ssh_keys` object into the `ssh_key_id` within `./terraform/terraform.tfvars`.
 
+## Amazon CloudDrive
+
+### OAuth Data
+
+In order to authenticate `acd_cli`, visit <https://tensile-runway-92512.appspot.com/> and copy the downloaded data file to `./provisioning/roles/aws/files/oauth_data` (no extension).
+
 ## Plex
 
 ### Claim Token

--- a/do_it.sh
+++ b/do_it.sh
@@ -14,6 +14,13 @@ if ! grep -q ssh_key_id ./terraform/terraform.tfvars; then
   exit 1
 fi
 
+if ! grep -q "CLAIM_TOKEN: claim-" ./provisioning/group_vars/all.yml; then
+  echo "Missing CLAIM_TOKEN from group_vars"
+  read -p "Press Enter to open claim token site..."
+  open "https://www.plex.tv/claim/"
+  exit 1
+fi
+
 if [ ! -f ./provisioning/roles/aws/files/oauth_data ]; then
   echo "Missing 'oauth_data' from aws files"
   read -p "Press Enter to open the site for oauth_data...."

--- a/do_it.sh
+++ b/do_it.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+if [ ! -f ./terraform/terraform.tfvars ]; then
+  echo "Missing ./terraform/terraform.tfvars file"
+  exit 1
+fi
+
+if ! grep -q do_token ./terraform/terraform.tfvars; then
+  echo "Missing 'do_token' from terraform.tfvars"
+  exit 1
+fi
+
+if ! grep -q ssh_key_id ./terraform/terraform.tfvars; then
+  echo "Missing 'ssh_key_id' from terraform.tfvars"
+  exit 1
+fi
+
+if [ ! -f ./provisioning/roles/aws/files/oauth_data ]; then
+  echo "Missing 'oauth_data' from aws files"
+  read -p "Press Enter to open the site for oauth_data...."
+  open 'https://tensile-runway-92512.appspot.com/'
+  while [ ! -f ~/Downloads/oauth_data.html ]; do
+    sleep 2
+  done
+  echo "Automatically moving oauth_data file..."
+  mv ~/Downloads/oauth_data.html ./provisioning/roles/aws/files/oauth_data
+fi
+
+pushd ./terraform/
+terraform apply
+while ! ansible --inventory-file=$(which terraform-inventory) -m ping all; do
+  echo "Waiting for machine to come online..."
+  sleep 5
+done
+./ansible.sh

--- a/do_it.sh
+++ b/do_it.sh
@@ -16,7 +16,7 @@ fi
 
 if ! grep -q "CLAIM_TOKEN: claim-" ./provisioning/group_vars/all.yml; then
   echo "Missing CLAIM_TOKEN from group_vars"
-  read -p "Press Enter to open claim token site..."
+  read -p "Press Enter to open claim token site, past result into ./provisioning/group_vars/all.yml"
   open "https://www.plex.tv/claim/"
   exit 1
 fi

--- a/provisioning/ansible.cfg
+++ b/provisioning/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
-inventory = ./hosts
-retry_files_enabled = False
+host_key_checking = False
 remote_user = root
+retry_files_enabled = False
 [privilege_escalation]
 become = True

--- a/provisioning/group_vars/all.yml
+++ b/provisioning/group_vars/all.yml
@@ -3,3 +3,4 @@ PUID: 0
 GUID: 0
 TZ: America/Chicago
 PLEX_HOSTNAME: Docker
+CLAIM_TOKEN:

--- a/provisioning/roles/aws/files/put_oauth_data_here
+++ b/provisioning/roles/aws/files/put_oauth_data_here
@@ -1,0 +1,1 @@
+{ "access_token": "", "expires_in": 3600, "refresh_token": "", "token_type": "bearer" }

--- a/provisioning/roles/aws/tasks/main.yml
+++ b/provisioning/roles/aws/tasks/main.yml
@@ -13,17 +13,21 @@
 
 - file: path=~/acd state=directory
 
-- shell: acd_cli ls
+- name: Check for ACD connection
+  shell: acd_cli ls
   register: acd_stat
+  ignore_errors: yes
 
-- copy: src=oauth_data dest=~/.cache/acd_cli/oauth_data
+- name: Pushing up oauth_data file
+  copy: src=oauth_data dest=~/.cache/acd_cli/oauth_data
   when: acd_stat.rc != 0
 
 - name: sync up ACD
-  shell: acd_cli sync
+  shell: acd_cli psync -r /
   when: acd_stat.rc != 0
 
-- command: mountpoint -q ~/acd
+- name: Verify ACD mount point
+  command: mountpoint -q ~/acd
   register: volume_stat
   failed_when: False
   changed_when: False
@@ -45,8 +49,8 @@
     - movies
     - tvshows
 
-- name: Mount UnionFS {{item}}
-  mount: name=/root/{{item}} src="/root/local/{{item}}=RW:/root/acd/{{item}}=RO" fstype=fuse.unionfs-fuse opts=allow_other,cow,use_ino state=mounted
+- name: Mount UnionFS dirs
+  mount: name=/root/{{item}} src="/root/acd/{{item}}=RO:/root/local/{{item}}=RW" fstype=fuse.unionfs-fuse opts=allow_other,cow,use_ino state=mounted
   with_items:
     - tvshows
     - movies

--- a/provisioning/roles/aws/tasks/main.yml
+++ b/provisioning/roles/aws/tasks/main.yml
@@ -7,4 +7,33 @@
     - python3-requests
     - python3-sqlalchemy
     - python3-pip
+
 - pip: name="git+https://github.com/yadayada/acd_cli.git" executable=pip3 editable=false
+
+- file: path=~/acd state=directory
+
+- copy: src=oauth_data dest=~/.cache/acd_cli/oauth_data
+- name: sync up ACD
+  shell: acd_cli sync
+
+- command: mountpoint -q ~/acd
+  register: volume_stat
+  failed_when: False
+  changed_when: False
+
+- name: Mount CloudDrive to ~/acd
+  shell: acd_cli mount ~/acd
+  when: volume_stat.rc != 0
+
+- shell: acd_cli mkdir /{{item}}
+  with_items:
+    - movies
+    - tvshows
+  args:
+    creates: ~/acd/{{item}}
+
+- name: schedule ACD uploads
+  cron: job="acd_cli upload /root/local/{{item}} /{{item}} -rsf" special_time=daily
+  with_items:
+    - movies
+    - tvshows

--- a/provisioning/roles/aws/tasks/main.yml
+++ b/provisioning/roles/aws/tasks/main.yml
@@ -33,7 +33,7 @@
   changed_when: False
 
 - name: Mount CloudDrive to ~/acd
-  shell: acd_cli mount ~/acd
+  shell: acd_cli mount ~/acd --allow-other --umask 000
   when: volume_stat.rc != 0
 
 - shell: acd_cli mkdir /{{item}}
@@ -54,3 +54,5 @@
   with_items:
     - tvshows
     - movies
+  ignore_errors: yes
+  # this is to work around a bug where ansible can't seem to remount

--- a/provisioning/roles/aws/tasks/main.yml
+++ b/provisioning/roles/aws/tasks/main.yml
@@ -7,14 +7,21 @@
     - python3-requests
     - python3-sqlalchemy
     - python3-pip
+    - unionfs-fuse
 
 - pip: name="git+https://github.com/yadayada/acd_cli.git" executable=pip3 editable=false
 
 - file: path=~/acd state=directory
 
+- shell: acd_cli ls
+  register: acd_stat
+
 - copy: src=oauth_data dest=~/.cache/acd_cli/oauth_data
+  when: acd_stat.rc != 0
+
 - name: sync up ACD
   shell: acd_cli sync
+  when: acd_stat.rc != 0
 
 - command: mountpoint -q ~/acd
   register: volume_stat
@@ -33,7 +40,13 @@
     creates: ~/acd/{{item}}
 
 - name: schedule ACD uploads
-  cron: job="acd_cli upload /root/local/{{item}} /{{item}} -rsf" special_time=daily
+  cron: job="acd_cli upload -x 2 -r 5 /root/local/{{item}}/* /{{item}}/ -rsf" special_time=daily name="Upload {{item}}"
   with_items:
     - movies
     - tvshows
+
+- name: Mount UnionFS {{item}}
+  mount: name=/root/{{item}} src="/root/local/{{item}}=RW:/root/acd/{{item}}=RO" fstype=fuse.unionfs-fuse opts=allow_other,cow,use_ino state=mounted
+  with_items:
+    - tvshows
+    - movies

--- a/provisioning/roles/core/tasks/main.yml
+++ b/provisioning/roles/core/tasks/main.yml
@@ -15,3 +15,5 @@
 
 - ufw: port=ssh rule=allow
 - ufw: state=enabled policy=deny
+
+- include: mounts.yml

--- a/provisioning/roles/core/tasks/main.yml
+++ b/provisioning/roles/core/tasks/main.yml
@@ -12,3 +12,6 @@
   ipify_facts:
   connection: local
   become: False
+
+- ufw: port=ssh rule=allow
+- ufw: state=enabled policy=deny

--- a/provisioning/roles/core/tasks/mounts.yml
+++ b/provisioning/roles/core/tasks/mounts.yml
@@ -1,0 +1,16 @@
+---
+- name: Prep UnionFS mount dirs
+  command: mkdir -p ~/{{item}}
+  with_items:
+    - tvshows
+    - movies
+  args:
+    creates: ~/{{item}}
+
+- name: Prep local dirs
+  command: mkdir -p ~/local/{{item}}
+  with_items:
+    - tvshows
+    - movies
+  args:
+    creates: ~/local/{{item}}

--- a/provisioning/roles/couchpotato/tasks/main.yml
+++ b/provisioning/roles/couchpotato/tasks/main.yml
@@ -8,7 +8,7 @@
     image: linuxserver/couchpotato
     volumes:
       - "/root/couchpotato/config:/config"
-      - "/root/movies:/movies"
+      - "/root/local/movies:/movies"
       - "/root/downloads:/downloads"
     links:
       - transmission

--- a/provisioning/roles/docker/files/docker
+++ b/provisioning/roles/docker/files/docker
@@ -1,1 +1,1 @@
-DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4 --iptables=false" 
+DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4"

--- a/provisioning/roles/plex/tasks/main.yml
+++ b/provisioning/roles/plex/tasks/main.yml
@@ -10,6 +10,10 @@
       - "/root/transcoding:/transcoding"
     ports:
       - "32400:32400/tcp"
+      - "32410:32410/tcp"
+      - "32412:32412/tcp"
+      - "32413:32413/tcp"
+      - "32414:32414/tcp"
     env:
       PUID: "{{PUID}}"
       GUID: "{{GUID}}"

--- a/provisioning/roles/plex/tasks/main.yml
+++ b/provisioning/roles/plex/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Create a Plex container
   docker_container:
     name: plex
-    image: plexinc/pms-docker
+    image: plexinc/pms-docker:plexpass
     volumes:
       - "/root/plex/config:/config"
       - "/root/tvshows:/data/tvshows"
@@ -15,10 +15,9 @@
       - "32413:32413/tcp"
       - "32414:32414/tcp"
     env:
-      PUID: "{{PUID}}"
-      GUID: "{{GUID}}"
       TZ: "{{TZ}}"
-      ADVERTISE_IP: "{{ansible_default_ipv4.address}}"
+      ADVERTISE_IP: "http://{{ansible_default_ipv4.address}}:32400/"
+      PLEX_CLAIM: "{{CLAIM_TOKEN}}"
     hostname: "{{PLEX_HOSTNAME}}"
 
 - name: Allow remote access

--- a/provisioning/roles/sonarr/tasks/main.yml
+++ b/provisioning/roles/sonarr/tasks/main.yml
@@ -5,7 +5,7 @@
     image: linuxserver/sonarr
     volumes:
       - "/root/sonarr/config:/config"
-      - "/root/tvshows:/tv"
+      - "/root/local/tvshows:/tv"
       - "/root/downloads:/downloads"
     links:
       - transmission

--- a/terraform/digitalocean.tf
+++ b/terraform/digitalocean.tf
@@ -9,6 +9,6 @@ resource "digitalocean_droplet" "web" {
   image = "docker-16-04"
   name = "docker-1"
   region = "nyc2"
-  size = "1gb"
+  size = "4gb"
   ssh_keys = ["${var.ssh_key_id}"]
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,2 @@
+do_token = ""
+ssh_key_id = ""


### PR DESCRIPTION
This PR does a few things:

1. Adds a convenient `./do_it.sh` script that does a few sanity checks for the user before running
2. Expands the `aws` role to mount Amazon CloudDrive to `/root/acd/`
3. Uses [Unionfs](http://unionfs.filesystems.org) to present a unified folder for Plex to read media from